### PR TITLE
Bugfix: Use non-templated std::abs

### DIFF
--- a/math/line2d.h
+++ b/math/line2d.h
@@ -84,7 +84,7 @@ struct Line {
     } else if (math_util::Sq(x) > (p1 - p0).squaredNorm()) {
       return (p - p1).norm();
     }
-    return std::abs<T>(geometry::Perp(dir).dot(p - p0));
+    return std::abs(geometry::Perp(dir).dot(p - p0));
   }
 
   bool CloserThan(const Vector2T& p2,


### PR DESCRIPTION
Fixes a clang-12 compilation error

Related: https://github.com/ut-amrl/graph_navigation/pull/41